### PR TITLE
Support passing Docker container options.

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -69,13 +69,15 @@ func runDaemon(ctx context.Context, envFile string) func(cmd *cobra.Command, arg
 		)
 
 		runner := &runtime.Runner{
-			Client:        cli,
-			Machine:       cfg.Runner.Name,
-			ForgeInstance: cfg.Client.Address,
-			Environ:       cfg.Runner.Environ,
-			Labels:        cfg.Runner.Labels,
-			Version:       version,
-			CacheHandler:  handler,
+			Client:                 cli,
+			Machine:                cfg.Runner.Name,
+			ForgeInstance:          cfg.Client.Address,
+			Environ:                cfg.Runner.Environ,
+			Labels:                 cfg.Runner.Labels,
+			Version:                version,
+			CacheHandler:           handler,
+			DockerContainerOptions: cfg.Runner.DockerContainerOptions,
+			DockerPrivileged:       cfg.Runner.DockerPrivileged,
 		}
 
 		poller := poller.New(

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -48,6 +48,7 @@ type executeArgs struct {
 	useGitIgnore          bool
 	containerCapAdd       []string
 	containerCapDrop      []string
+	containerOptions      string
 	artifactServerPath    string
 	artifactServerAddr    string
 	artifactServerPort    string
@@ -375,6 +376,7 @@ func runExec(ctx context.Context, execArgs *executeArgs) func(cmd *cobra.Command
 			// GitHubInstance:        t.client.Address(),
 			ContainerCapAdd:    execArgs.containerCapAdd,
 			ContainerCapDrop:   execArgs.containerCapDrop,
+			ContainerOptions:   execArgs.containerOptions,
 			AutoRemove:         true,
 			ArtifactServerPath: execArgs.artifactServerPath,
 			ArtifactServerPort: execArgs.artifactServerPort,
@@ -456,6 +458,7 @@ func loadExecCmd(ctx context.Context) *cobra.Command {
 	execCmd.Flags().BoolVar(&execArg.useGitIgnore, "use-gitignore", true, "Controls whether paths specified in .gitignore should be copied into container")
 	execCmd.Flags().StringArrayVarP(&execArg.containerCapAdd, "container-cap-add", "", []string{}, "kernel capabilities to add to the workflow containers (e.g. --container-cap-add SYS_PTRACE)")
 	execCmd.Flags().StringArrayVarP(&execArg.containerCapDrop, "container-cap-drop", "", []string{}, "kernel capabilities to remove from the workflow containers (e.g. --container-cap-drop SYS_PTRACE)")
+	execCmd.Flags().StringVarP(&execArg.containerOptions, "container-opts", "", "", "container options")
 	execCmd.PersistentFlags().StringVarP(&execArg.artifactServerPath, "artifact-server-path", "", ".", "Defines the path where the artifact server stores uploads and retrieves downloads from. If not specified the artifact server will not start.")
 	execCmd.PersistentFlags().StringVarP(&execArg.artifactServerPort, "artifact-server-port", "", "34567", "Defines the port where the artifact server listens (will only bind to localhost).")
 	execCmd.PersistentFlags().StringVarP(&execArg.defaultActionsUrl, "default-actions-url", "", "https://gitea.com", "Defines the default url of action instance.")

--- a/config/config.go
+++ b/config/config.go
@@ -32,14 +32,17 @@ type (
 	}
 
 	Runner struct {
-		UUID     string            `ignored:"true"`
-		Name     string            `envconfig:"GITEA_RUNNER_NAME"`
-		Token    string            `ignored:"true"`
-		Capacity int               `envconfig:"GITEA_RUNNER_CAPACITY" default:"1"`
-		File     string            `envconfig:"GITEA_RUNNER_FILE" default:".runner"`
-		Environ  map[string]string `envconfig:"GITEA_RUNNER_ENVIRON"`
-		EnvFile  string            `envconfig:"GITEA_RUNNER_ENV_FILE"`
-		Labels   []string          `envconfig:"GITEA_RUNNER_LABELS"`
+		UUID                   string            `ignored:"true"`
+		Name                   string            `envconfig:"GITEA_RUNNER_NAME"`
+		Token                  string            `ignored:"true"`
+		Capacity               int               `envconfig:"GITEA_RUNNER_CAPACITY" default:"1"`
+		File                   string            `envconfig:"GITEA_RUNNER_FILE" default:".runner"`
+		Environ                map[string]string `envconfig:"GITEA_RUNNER_ENVIRON"`
+		EnvFile                string            `envconfig:"GITEA_RUNNER_ENV_FILE"`
+		Labels                 []string          `envconfig:"GITEA_RUNNER_LABELS"`
+		DockerContainerOptions string            `envconfig:"GITEA_RUNNER_DOCKER_CONTAINER_OPTIONS"`
+		DockerNetworkMode      string            `envconfig:"GITEA_RUNNER_DOCKER_NETWORK_MODE" default:"bridge"`
+		DockerPrivileged       bool              `envconfig:"GITEA_RUNNER_DOCKER_PRIVILEGED" default:"false"`
 	}
 
 	Platform struct {
@@ -83,6 +86,15 @@ func FromEnviron() (Config, error) {
 		if runner.Insecure != "" {
 			cfg.Client.Insecure, _ = strconv.ParseBool(runner.Insecure)
 		}
+		if runner.DockerPrivileged != "" {
+			cfg.Runner.DockerPrivileged, _ = strconv.ParseBool(runner.DockerPrivileged)
+		}
+		if runner.DockerContainerOptions != "" {
+			cfg.Runner.DockerContainerOptions = runner.DockerContainerOptions
+		}
+		if runner.DockerNetworkMode != "" {
+			cfg.Runner.DockerNetworkMode = runner.DockerNetworkMode
+		}
 	} else if err != nil {
 		return cfg, err
 	}
@@ -96,6 +108,10 @@ func FromEnviron() (Config, error) {
 	}
 	if cfg.Runner.Name == "" {
 		cfg.Runner.Name, _ = os.Hostname()
+	}
+
+	if cfg.Runner.DockerNetworkMode == "" {
+		cfg.Runner.DockerNetworkMode = "bridge"
 	}
 
 	// platform config

--- a/core/runner.go
+++ b/core/runner.go
@@ -11,11 +11,14 @@ const (
 
 // Runner struct
 type Runner struct {
-	ID       int64    `json:"id"`
-	UUID     string   `json:"uuid"`
-	Name     string   `json:"name"`
-	Token    string   `json:"token"`
-	Address  string   `json:"address"`
-	Insecure string   `json:"insecure"`
-	Labels   []string `json:"labels"`
+	ID                     int64    `json:"id"`
+	UUID                   string   `json:"uuid"`
+	Name                   string   `json:"name"`
+	Token                  string   `json:"token"`
+	Address                string   `json:"address"`
+	Insecure               string   `json:"insecure"`
+	Labels                 []string `json:"labels"`
+	DockerContainerOptions string   `json:"dockerContainerOptions"`
+	DockerNetworkMode      string   `json:"dockerNetworkMode"`
+	DockerPrivileged       string   `json:"dockerPrivileged"`
 }

--- a/register/register.go
+++ b/register/register.go
@@ -46,13 +46,16 @@ func (p *Register) Register(ctx context.Context, cfg config.Runner) (*core.Runne
 	}
 
 	data := &core.Runner{
-		ID:       resp.Msg.Runner.Id,
-		UUID:     resp.Msg.Runner.Uuid,
-		Name:     resp.Msg.Runner.Name,
-		Token:    resp.Msg.Runner.Token,
-		Address:  p.Client.Address(),
-		Insecure: strconv.FormatBool(p.Client.Insecure()),
-		Labels:   cfg.Labels,
+		ID:                     resp.Msg.Runner.Id,
+		UUID:                   resp.Msg.Runner.Uuid,
+		Name:                   resp.Msg.Runner.Name,
+		Token:                  resp.Msg.Runner.Token,
+		Address:                p.Client.Address(),
+		Insecure:               strconv.FormatBool(p.Client.Insecure()),
+		Labels:                 cfg.Labels,
+		DockerNetworkMode:      cfg.DockerNetworkMode,
+		DockerContainerOptions: cfg.DockerContainerOptions,
+		DockerPrivileged:       strconv.FormatBool(cfg.DockerPrivileged),
 	}
 
 	file, err := json.MarshalIndent(data, "", "  ")

--- a/runtime/task.go
+++ b/runtime/task.go
@@ -52,6 +52,7 @@ type TaskInput struct {
 	useGitIgnore     bool
 	containerCapAdd  []string
 	containerCapDrop []string
+	containerOptions string
 	// autoRemove         bool
 	artifactServerPath string
 	artifactServerPort string
@@ -74,13 +75,10 @@ type Task struct {
 }
 
 // NewTask creates a new task
-func NewTask(forgeInstance string, buildID int64, client client.Client, runnerEnvs map[string]string, picker func([]string) string) *Task {
+func NewTask(forgeInstance string, buildID int64, client client.Client, taskInput *TaskInput, picker func([]string) string) *Task {
+	client.Insecure()
 	task := &Task{
-		Input: &TaskInput{
-			envs:                 runnerEnvs,
-			containerNetworkMode: "bridge", // TODO should be configurable
-			privileged:           true,     // TODO should be configurable
-		},
+		Input:   taskInput,
 		BuildID: buildID,
 
 		client:         client,
@@ -233,6 +231,7 @@ func (t *Task) Run(ctx context.Context, task *runnerv1.Task, runnerName, runnerV
 		GitHubInstance:        t.client.Address(),
 		ContainerCapAdd:       input.containerCapAdd,
 		ContainerCapDrop:      input.containerCapDrop,
+		ContainerOptions:      input.containerOptions,
 		AutoRemove:            true,
 		ArtifactServerPath:    input.artifactServerPath,
 		ArtifactServerPort:    input.artifactServerPort,


### PR DESCRIPTION
For example, in `.runner`:

```
  "dockerContainerOptions": "--add-host=gitea.local:host-gateway",
  "dockerNetworkMode": "bridge",
  "dockerPrivileged": "true"
```